### PR TITLE
move refresher to async xmlhttpreq to keep chrome from complaining

### DIFF
--- a/fresh/static/fresh/js/refresher.js
+++ b/fresh/static/fresh/js/refresher.js
@@ -1,19 +1,19 @@
 function checkRefresh() {
     var req = new XMLHttpRequest();
 
-    req.open('GET', '/fresh/', false);
+    req.open('GET', '/fresh/', true);
+    req.onreadystatechange = function () {
+        if (req.readyState == 4) { // done
+            var fresh = JSON.parse(req.responseText).fresh;
+            if (fresh) location.reload();
+        }
+    };
+
     req.send();
-
-    var fresh = JSON.parse(req.responseText).fresh;
-    if (fresh) location.reload();
-
-    doPoll();
 }
 
 function doPoll() {
-    setTimeout(function() {
-        checkRefresh();
-    }, 1000);
+    setInterval(  checkRefresh , 1000);
 }
 
 doPoll();


### PR DESCRIPTION
Latest version of Chrome complains that the user experience is
impaired by sync xmlhttpreqs on the main thread.

This patch changes the AJAX call to an async model, delivering
a better user experience.

Signed-off-by: ddalex <ddalex@gmail.com>